### PR TITLE
fix(database): lock real shard in GetKeyAmountPerShard

### DIFF
--- a/internal/database/database.go
+++ b/internal/database/database.go
@@ -68,7 +68,14 @@ func getShard(key string, shardAmount int) int {
 func (db *Database) GetKeyAmountPerShard() []int {
 	amountPerShard := make([]int, 0, len(db.shards))
 
-	for _, shard := range db.shards {
+	// Iterate by index so shard is a pointer to the real slice element.
+	// The previous `for _, shard := range db.shards` copied the
+	// databaseShard value (including its sync.RWMutex), so the RLock was
+	// taken on a per-iteration copy and left the real shard unlocked;
+	// concurrent Set/Del calls hit by -race and could see a torn
+	// len(shard.data).
+	for i := range db.shards {
+		shard := &db.shards[i]
 		shard.mu.RLock()
 		amountPerShard = append(amountPerShard, len(shard.data))
 		shard.mu.RUnlock()

--- a/internal/database/database_test.go
+++ b/internal/database/database_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/robin-vidal/kvgo/internal/config"
 )
@@ -258,4 +259,53 @@ func TestGetKeyAmountPerShard(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGetKeyAmountPerShard_RaceWithSetDel guards issue #28: prior to the
+// pointer-iter fix, GetKeyAmountPerShard ranged over db.shards by value,
+// copying each shard (including its sync.RWMutex) so the RLock was taken
+// on the per-iteration copy and the real shard stayed unlocked. That
+// reliably fired -race against concurrent Set/Del.
+func TestGetKeyAmountPerShard_RaceWithSetDel(t *testing.T) {
+	db := New(generateSampleConfig(8))
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 0
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			k := fmt.Sprintf("k%d", i%128)
+			db.Set(k, "v")
+			db.Delete(k)
+			i++
+		}
+	}()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for j := 0; j < 2000; j++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			_ = db.GetKeyAmountPerShard()
+		}
+	}()
+
+	// Let the workload run briefly then signal stop. The race detector
+	// fires at goroutine-exit time if any interleaving occurred, so the
+	// duration just needs to be long enough to produce overlap.
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	wg.Wait()
 }


### PR DESCRIPTION
Fixes robin-vidal/kvgo#28.

## Problem

`for _, shard := range db.shards` copied each `databaseShard` (including its `sync.RWMutex`) per iteration, so `shard.mu.RLock()` locked the copy and left the real shard unlocked. Concurrent `Set`/`Delete` hit by `go test -race`, and nothing prevented a torn read of `len(shard.data)`.

## Fix

Iterate by index and use `&db.shards[i]` so `RLock`/`RUnlock` operate on the real shard.

## Test

Added `TestGetKeyAmountPerShard_RaceWithSetDel` which pounds `Set`/`Delete` against repeated `GetKeyAmountPerShard` calls. Passes under `-race` with the fix; reliably fires DATA RACE against the previous code.