### PR TITLE
fix: match command names case-insensitively

### DIFF
--- a/internal/command/registry.go
+++ b/internal/command/registry.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/robin-vidal/kvgo/internal/database"
 	"github.com/robin-vidal/kvgo/internal/resp"
@@ -57,6 +58,7 @@ func (r *registry) register(s *spec) {
 }
 
 func Dispatch(st *store.Store, name string, args []string) result {
+	name = strings.ToUpper(name)
 	entry, found := defaultRegistry.commands[name]
 	if !found {
 		return result{

--- a/internal/command/registry_test.go
+++ b/internal/command/registry_test.go
@@ -203,6 +203,26 @@ func TestDispatch(t *testing.T) {
 			wantStatus:  "ok",
 		},
 		{
+			name:        "lowercase SET",
+			setup:       func(db *database.Database) {},
+			cmd:         "set",
+			args:        []string{"foo", "bar"},
+			wantResp:    resp.EncodeSimpleString("OK"),
+			wantCmdName: "SET",
+			wantStatus:  "ok",
+		},
+		{
+			name: "mixed-case GET",
+			setup: func(db *database.Database) {
+				db.Set("foo", "bar")
+			},
+			cmd:         "gEt",
+			args:        []string{"foo"},
+			wantResp:    resp.EncodeBulkString("bar"),
+			wantCmdName: "GET",
+			wantStatus:  "ok",
+		},
+		{
 			name: "GET Hit",
 			setup: func(db *database.Database) {
 				db.Set("foo", "bar")


### PR DESCRIPTION
## Summary
- normalize top-level command names before registry lookup
- cover lowercase `SET` and mixed-case `GET` dispatch

## Testing
- `GOPROXY=direct go test -race ./... -count=1`
- raw RESP TCP surface with lowercase `ping`, mixed-case `SeT`, and mixed-case `gEt`

Closes #62